### PR TITLE
cost matrices for near-network observations

### DIFF
--- a/tigernet/__init__.py
+++ b/tigernet/__init__.py
@@ -4,7 +4,7 @@ __version__ = "v0.1-prealpha"
 `tigernet` --- "Network Topology via TIGER/Line Shapefiles"
 """
 
-from .tigernet import Network, Observations
+from .tigernet import Network, Observations, obs2obs_cost_matrix
 
 from .generate_data import testing_data, generate_lattice
 from .generate_data import generate_sine_lines, generate_obs

--- a/tigernet/tests/network_objects.py
+++ b/tigernet/tests/network_objects.py
@@ -120,6 +120,18 @@ _, network_barb_wpaths_inplace_var = copy.deepcopy(network_barb).cost_matrix(
     wpaths=True, asattr=False
 )
 
+# --------------------------------------------------------------------------
+# One 1x1 lattice network with smaller bounds
+#   used in:
+#       - test_obs2obs_synthetic.TestSyntheticObservationsOrigToXXXXSegments
+#       - test_obs2obs_synthetic.TestSyntheticObservationsOrigToXXXXNodes
+#       - test_obs2obs_synthetic.TestSyntheticObservationsOrigToDestSegments
+#       - test_obs2obs_synthetic.TestSyntheticObservationsOrigToDestNodes
+h1v1 = {"n_hori_lines": 1, "n_vert_lines": 1}
+lattice = tigernet.generate_lattice(bounds=[0, 0, 4, 4], **h1v1)
+network_lattice_1x1_small = tigernet.Network(s_data=lattice, **kws)
+network_lattice_1x1_small.cost_matrix()
+
 
 ###############################################################################
 ############################### Empirical networks ############################

--- a/tigernet/tests/network_objects.py
+++ b/tigernet/tests/network_objects.py
@@ -211,5 +211,9 @@ network_empirical_simplified.simplify_network(inplace=True, **kws)
 #       - test_stats.TestNetworkStatsEmpirical
 #       - test_stats.TestNetworkDistanceMetricsEmpiricalGDF
 #       - test_cost_matrix.TestNetworkCostMatrixEmpircalGDF
+#       - test_observations_empirical.TestEmpiricalObservationsOrigToXXXXSegments
+#       - test_observations_empirical.TestEmpiricalObservationsOrigToXXXXNodes
+#       - test_observations_empirical.
+#       - test_observations_empirical.
 network_empirical_simplified_wcm = copy.deepcopy(network_empirical_simplified)
 network_empirical_simplified_wcm.cost_matrix(wpaths=True)

--- a/tigernet/tests/test_obs2obs_empirical.py
+++ b/tigernet/tests/test_obs2obs_empirical.py
@@ -1,0 +1,275 @@
+"""Synthetic observation data testing.
+"""
+
+import copy
+import unittest
+import numpy
+
+import tigernet
+from .network_objects import network_empirical_simplified_wcm
+
+
+####################################################################################
+############################# ORIG-XXXX--Segments ##################################
+####################################################################################
+
+
+class TestEmpiricalObservationsOrigToXXXXSegments(unittest.TestCase):
+    def setUp(self):
+        self.network = copy.deepcopy(network_empirical_simplified_wcm)
+
+        # empirical observations
+        obs = tigernet.testing_data("CensusBlocks_Leon_FL_2010")
+
+        # associate observations with the network
+        args = self.network, obs.copy()
+        kwargs = {"df_name": "obs1", "df_key": "GEOID"}
+        self.net_obs = tigernet.Observations(*args, **kwargs)
+
+    def test_net_no_snap(self):
+        known_mtx = numpy.array(
+            [
+                [0.0, 3285.69020577, 3883.24256199, 3581.0882225],
+                [3285.69020577, 0.0, 645.01865974, 3264.87455121],
+                [3883.24256199, 645.01865974, 0.0, 3909.89321095],
+                [3581.0882225, 3264.87455121, 3909.89321095, 0.0],
+            ]
+        )
+        args = copy.deepcopy(self.net_obs), copy.deepcopy(self.network)
+        kwargs = {
+            "destination_observations": None,
+            "snap_dist": False,
+            "distance_type": "network",
+        }
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx[:4, :4], known_mtx)
+
+        known_mtx_sum = 22144649.49077968
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+    def test_net_snap(self):
+        known_mtx = numpy.array(
+            [
+                [0.0, 3389.37545944, 3975.65875829, 3687.64355986],
+                [3389.37545944, 0.0, 727.84658824, 3361.84162077],
+                [3975.65875829, 727.84658824, 0.0, 3995.59122314],
+                [3687.64355986, 3361.84162077, 3995.59122314, 0.0],
+            ]
+        )
+        args = copy.deepcopy(self.net_obs), copy.deepcopy(self.network)
+        kwargs = {
+            "destination_observations": None,
+            "snap_dist": True,
+            "distance_type": "network",
+        }
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx[:4, :4], known_mtx)
+
+        known_mtx_sum = 23283690.15943207
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+
+####################################################################################
+############################# ORIG-XXXX--Nodes #####################################
+####################################################################################
+
+
+class TestEmpiricalObservationsOrigToXXXXNodes(unittest.TestCase):
+    def setUp(self):
+        self.network = copy.deepcopy(network_empirical_simplified_wcm)
+
+        # empirical observations
+        obs = tigernet.testing_data("CensusBlocks_Leon_FL_2010")
+
+        # associate observations with the network
+        args = self.network, obs.copy()
+        kwargs = {"df_name": "obs1", "df_key": "GEOID", "snap_to": "nodes"}
+        self.net_obs = tigernet.Observations(*args, **kwargs)
+
+    def test_net_no_snap(self):
+        known_mtx = numpy.array(
+            [
+                [0.0, 3317.88793311, 4003.17771763, 3387.79485659],
+                [3317.88793311, 0.0, 940.71263515, 3273.42506072],
+                [4003.17771763, 940.71263515, 0.0, 3836.53500068],
+                [3387.79485659, 3273.42506072, 3836.53500068, 0.0],
+            ]
+        )
+        args = self.net_obs, self.network
+        kwargs = {
+            "destination_observations": None,
+            "snap_dist": False,
+            "distance_type": "network",
+        }
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx[:4, :4], known_mtx)
+
+        known_mtx_sum = 22077455.792563077
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+    def test_net_snap(self):
+        known_mtx = numpy.array(
+            [
+                [0.0, 3501.0453002, 4171.59260934, 3611.91094868],
+                [3501.0453002, 0.0, 1027.01398167, 3415.42760763],
+                [4171.59260934, 1027.01398167, 0.0, 3963.79507221],
+                [3611.91094868, 3415.42760763, 3963.79507221, 0.0],
+            ]
+        )
+        args = self.net_obs, self.network
+        kwargs = {
+            "destination_observations": None,
+            "snap_dist": True,
+            "distance_type": "network",
+        }
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx[:4, :4], known_mtx)
+
+        known_mtx_sum = 23904433.77183481
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+
+####################################################################################
+############################# ORIG-DEST--Segments ##################################
+####################################################################################
+
+
+class TestEmpiricalObservationsOrigToDestSegments(unittest.TestCase):
+    def setUp(self):
+        self.network = copy.deepcopy(network_empirical_simplified_wcm)
+
+        # empirical origins
+        obs1 = tigernet.testing_data("CensusBlocks_Leon_FL_2010")
+        # empirical destinations
+        obs2 = tigernet.testing_data("WeightedParcels_Leon_FL_2010")
+
+        # associate origins with the network
+        args = self.network, obs1.copy()
+        kwargs = {"df_name": "obs1", "df_key": "GEOID"}
+        self.net_obs1 = tigernet.Observations(*args, **kwargs)
+
+        # associate destinations with the network
+        args = self.network, obs2.copy()
+        kwargs = {"df_name": "obs2", "df_key": "PARCEL_ID"}
+        self.net_obs2 = tigernet.Observations(*args, **kwargs)
+
+    def test_net_no_snap(self):
+        known_mtx = numpy.array(
+            [
+                [2308.55782266, 1823.52901858, 1629.12550059, 1597.1534076],
+                [2412.21391635, 2166.96509055, 2869.67781642, 3773.3107486],
+                [3057.23257609, 2604.07173243, 3306.78445831, 4370.86310481],
+                [2295.44379456, 5095.29064061, 4900.88712262, 3105.34260925],
+            ]
+        )
+        args = copy.deepcopy(self.net_obs1), copy.deepcopy(self.network)
+        kwargs = {
+            "destination_observations": self.net_obs2,
+            "snap_dist": False,
+            "distance_type": "network",
+        }
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx[:4, :4], known_mtx)
+
+        known_mtx_sum = 470126303.68085647
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+    def test_net_snap(self):
+        known_mtx = numpy.array(
+            [
+                [2395.75317806, 1918.29966974, 1726.83999895, 1702.36034626],
+                [2489.82100395, 2252.14747391, 2957.80404698, 3868.92941945],
+                [3123.57060632, 2677.98505843, 3383.6416315, 4455.2127183],
+                [2375.92096584, 5183.34310766, 4991.88343687, 3203.8313638],
+            ]
+        )
+        args = copy.deepcopy(self.net_obs1), copy.deepcopy(self.network)
+        kwargs = {
+            "destination_observations": self.net_obs2,
+            "snap_dist": True,
+            "distance_type": "network",
+        }
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx[:4, :4], known_mtx)
+
+        known_mtx_sum = 489927946.32060623
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+
+####################################################################################
+############################# ORIG-DEST--Nodes #####################################
+####################################################################################
+
+
+class TestEmpiricalObservationsOrigToDestNodes(unittest.TestCase):
+    def setUp(self):
+        self.network = copy.deepcopy(network_empirical_simplified_wcm)
+
+        # empirical origins
+        obs1 = tigernet.testing_data("CensusBlocks_Leon_FL_2010")
+        # empirical destinations
+        obs2 = tigernet.testing_data("WeightedParcels_Leon_FL_2010")
+
+        # associate origins with the network
+        args = self.network, obs1.copy()
+        kwargs = {"df_name": "obs1", "df_key": "GEOID", "snap_to": "nodes"}
+        self.net_obs1 = tigernet.Observations(*args, **kwargs)
+
+        # associate destinations with the network
+        args = self.network, obs2.copy()
+        kwargs = {"df_name": "obs2", "df_key": "PARCEL_ID", "snap_to": "nodes"}
+        self.net_obs2 = tigernet.Observations(*args, **kwargs)
+
+    def test_net_no_snap(self):
+        known_mtx = numpy.array(
+            [
+                [2064.59726946, 1899.48030691, 1749.06065623, 1567.86895727],
+                [2562.49978182, 2285.24409928, 2943.97295784, 3776.2240256],
+                [3125.60972178, 2648.05559975, 3306.78445831, 4461.51381012],
+                [2062.69976958, 4977.94856303, 4827.52891235, 3122.6351043],
+            ]
+        )
+        args = self.net_obs1, self.network
+        kwargs = {
+            "destination_observations": self.net_obs2,
+            "snap_dist": False,
+            "distance_type": "network",
+        }
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx[:4, :4], known_mtx)
+
+        known_mtx_sum = 467758744.4634375
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+    def test_net_snap(self):
+        known_mtx = numpy.array(
+            [
+                [2335.4438419, 2090.54629746, 1922.77385, 1803.34707265],
+                [2751.23280906, 2394.19654464, 3035.57260641, 3929.58859578],
+                [3299.60027364, 2742.26556972, 3383.6416315, 4600.13590492],
+                [2292.39152184, 5127.85973339, 4960.08728593, 3316.95839949],
+            ]
+        )
+        args = self.net_obs1, self.network
+        kwargs = {
+            "destination_observations": self.net_obs2,
+            "snap_dist": True,
+            "distance_type": "network",
+        }
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx[:4, :4], known_mtx)
+
+        known_mtx_sum = 503078065.92697436
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tigernet/tests/test_obs2obs_empirical.py
+++ b/tigernet/tests/test_obs2obs_empirical.py
@@ -46,7 +46,7 @@ class TestEmpiricalObservationsOrigToXXXXSegments(unittest.TestCase):
 
         known_mtx_sum = 22144649.49077968
         observed_mtx_sum = observed_mtx.sum()
-        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum, delta=1)
 
     def test_net_snap(self):
         known_mtx = numpy.array(
@@ -68,7 +68,7 @@ class TestEmpiricalObservationsOrigToXXXXSegments(unittest.TestCase):
 
         known_mtx_sum = 23283690.15943207
         observed_mtx_sum = observed_mtx.sum()
-        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum, delta=1)
 
 
 ####################################################################################
@@ -108,7 +108,7 @@ class TestEmpiricalObservationsOrigToXXXXNodes(unittest.TestCase):
 
         known_mtx_sum = 22077455.792563077
         observed_mtx_sum = observed_mtx.sum()
-        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum, delta=1)
 
     def test_net_snap(self):
         known_mtx = numpy.array(
@@ -130,7 +130,7 @@ class TestEmpiricalObservationsOrigToXXXXNodes(unittest.TestCase):
 
         known_mtx_sum = 23904433.77183481
         observed_mtx_sum = observed_mtx.sum()
-        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum, delta=1)
 
 
 ####################################################################################
@@ -177,7 +177,7 @@ class TestEmpiricalObservationsOrigToDestSegments(unittest.TestCase):
 
         known_mtx_sum = 470126303.68085647
         observed_mtx_sum = observed_mtx.sum()
-        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum, delta=1)
 
     def test_net_snap(self):
         known_mtx = numpy.array(
@@ -199,7 +199,7 @@ class TestEmpiricalObservationsOrigToDestSegments(unittest.TestCase):
 
         known_mtx_sum = 489927946.32060623
         observed_mtx_sum = observed_mtx.sum()
-        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum, delta=1)
 
 
 ####################################################################################
@@ -246,7 +246,7 @@ class TestEmpiricalObservationsOrigToDestNodes(unittest.TestCase):
 
         known_mtx_sum = 467758744.4634375
         observed_mtx_sum = observed_mtx.sum()
-        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum, delta=1)
 
     def test_net_snap(self):
         known_mtx = numpy.array(
@@ -268,7 +268,7 @@ class TestEmpiricalObservationsOrigToDestNodes(unittest.TestCase):
 
         known_mtx_sum = 503078065.92697436
         observed_mtx_sum = observed_mtx.sum()
-        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum, delta=1)
 
 
 if __name__ == "__main__":

--- a/tigernet/tests/test_obs2obs_synthetic.py
+++ b/tigernet/tests/test_obs2obs_synthetic.py
@@ -39,7 +39,11 @@ class TestSyntheticObservationsOrigToXXXXSegments(unittest.TestCase):
             ]
         )
         args = copy.deepcopy(self.net_obs), copy.deepcopy(self.network)
-        kwargs = {"dest_obs": None, "snap_dist": False, "distance_type": "network"}
+        kwargs = {
+            "destination_observations": None,
+            "snap_dist": False,
+            "distance_type": "network",
+        }
         observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
         numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
 
@@ -57,7 +61,11 @@ class TestSyntheticObservationsOrigToXXXXSegments(unittest.TestCase):
             ]
         )
         args = copy.deepcopy(self.net_obs), copy.deepcopy(self.network)
-        kwargs = {"dest_obs": None, "snap_dist": True, "distance_type": "network"}
+        kwargs = {
+            "destination_observations": None,
+            "snap_dist": True,
+            "distance_type": "network",
+        }
         observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
         numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
 
@@ -75,7 +83,11 @@ class TestSyntheticObservationsOrigToXXXXSegments(unittest.TestCase):
             ]
         )
         args = copy.deepcopy(self.net_obs), copy.deepcopy(self.network)
-        kwargs = {"dest_obs": None, "snap_dist": False, "distance_type": "euclidean"}
+        kwargs = {
+            "destination_observations": None,
+            "snap_dist": False,
+            "distance_type": "euclidean",
+        }
         observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
         numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
 
@@ -93,7 +105,11 @@ class TestSyntheticObservationsOrigToXXXXSegments(unittest.TestCase):
             ]
         )
         args = copy.deepcopy(self.net_obs), copy.deepcopy(self.network)
-        kwargs = {"dest_obs": None, "snap_dist": True, "distance_type": "euclidean"}
+        kwargs = {
+            "destination_observations": None,
+            "snap_dist": True,
+            "distance_type": "euclidean",
+        }
         observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
         numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
 
@@ -130,7 +146,11 @@ class TestSyntheticObservationsOrigToXXXXNodes(unittest.TestCase):
             ]
         )
         args = self.net_obs, self.network
-        kwargs = {"dest_obs": None, "snap_dist": False, "distance_type": "network"}
+        kwargs = {
+            "destination_observations": None,
+            "snap_dist": False,
+            "distance_type": "network",
+        }
         observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
         numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
 
@@ -148,7 +168,11 @@ class TestSyntheticObservationsOrigToXXXXNodes(unittest.TestCase):
             ]
         )
         args = self.net_obs, self.network
-        kwargs = {"dest_obs": None, "snap_dist": True, "distance_type": "network"}
+        kwargs = {
+            "destination_observations": None,
+            "snap_dist": True,
+            "distance_type": "network",
+        }
         observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
         numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
 
@@ -166,7 +190,11 @@ class TestSyntheticObservationsOrigToXXXXNodes(unittest.TestCase):
             ]
         )
         args = self.net_obs, self.network
-        kwargs = {"dest_obs": None, "snap_dist": False, "distance_type": "euclidean"}
+        kwargs = {
+            "destination_observations": None,
+            "snap_dist": False,
+            "distance_type": "euclidean",
+        }
         observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
         numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
 
@@ -184,7 +212,11 @@ class TestSyntheticObservationsOrigToXXXXNodes(unittest.TestCase):
             ]
         )
         args = self.net_obs, self.network
-        kwargs = {"dest_obs": None, "snap_dist": True, "distance_type": "euclidean"}
+        kwargs = {
+            "destination_observations": None,
+            "snap_dist": True,
+            "distance_type": "euclidean",
+        }
         observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
         numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
 
@@ -231,7 +263,7 @@ class TestSyntheticObservationsOrigToDestSegments(unittest.TestCase):
         )
         args = copy.deepcopy(self.net_obs1), copy.deepcopy(self.network)
         kwargs = {
-            "dest_obs": self.net_obs2,
+            "destination_observations": self.net_obs2,
             "snap_dist": False,
             "distance_type": "network",
         }
@@ -254,7 +286,7 @@ class TestSyntheticObservationsOrigToDestSegments(unittest.TestCase):
         )
         args = copy.deepcopy(self.net_obs1), copy.deepcopy(self.network)
         kwargs = {
-            "dest_obs": self.net_obs2,
+            "destination_observations": self.net_obs2,
             "snap_dist": True,
             "distance_type": "network",
         }
@@ -277,7 +309,7 @@ class TestSyntheticObservationsOrigToDestSegments(unittest.TestCase):
         )
         args = copy.deepcopy(self.net_obs1), copy.deepcopy(self.network)
         kwargs = {
-            "dest_obs": self.net_obs2,
+            "destination_observations": self.net_obs2,
             "snap_dist": False,
             "distance_type": "euclidean",
         }
@@ -300,7 +332,7 @@ class TestSyntheticObservationsOrigToDestSegments(unittest.TestCase):
         )
         args = copy.deepcopy(self.net_obs1), copy.deepcopy(self.network)
         kwargs = {
-            "dest_obs": self.net_obs2,
+            "destination_observations": self.net_obs2,
             "snap_dist": True,
             "distance_type": "euclidean",
         }
@@ -350,7 +382,7 @@ class TestSyntheticObservationsOrigToDestNodes(unittest.TestCase):
         )
         args = self.net_obs1, self.network
         kwargs = {
-            "dest_obs": self.net_obs2,
+            "destination_observations": self.net_obs2,
             "snap_dist": False,
             "distance_type": "network",
         }
@@ -373,7 +405,7 @@ class TestSyntheticObservationsOrigToDestNodes(unittest.TestCase):
         )
         args = self.net_obs1, self.network
         kwargs = {
-            "dest_obs": self.net_obs2,
+            "destination_observations": self.net_obs2,
             "snap_dist": True,
             "distance_type": "network",
         }
@@ -396,7 +428,7 @@ class TestSyntheticObservationsOrigToDestNodes(unittest.TestCase):
         )
         args = self.net_obs1, self.network
         kwargs = {
-            "dest_obs": self.net_obs2,
+            "destination_observations": self.net_obs2,
             "snap_dist": False,
             "distance_type": "euclidean",
         }
@@ -419,7 +451,7 @@ class TestSyntheticObservationsOrigToDestNodes(unittest.TestCase):
         )
         args = self.net_obs1, self.network
         kwargs = {
-            "dest_obs": self.net_obs2,
+            "destination_observations": self.net_obs2,
             "snap_dist": True,
             "distance_type": "euclidean",
         }

--- a/tigernet/tests/test_obs2obs_synthetic.py
+++ b/tigernet/tests/test_obs2obs_synthetic.py
@@ -1,0 +1,435 @@
+"""Synthetic observation data testing.
+"""
+
+import copy
+import unittest
+import geopandas
+import numpy
+from shapely.geometry import Point
+
+import tigernet
+from .network_objects import network_lattice_1x1_small
+
+
+####################################################################################
+############################# ORIG-XXXX--Segments ##################################
+####################################################################################
+
+
+class TestSyntheticObservationsOrigToXXXXSegments(unittest.TestCase):
+    def setUp(self):
+        self.network = copy.deepcopy(network_lattice_1x1_small)
+
+        # generate synthetic observations
+        pts = [Point(1, 1), Point(3, 1), Point(1, 3), Point(3, 3)]
+        obs = geopandas.GeoDataFrame({"obs_id": ["a", "b", "c", "d"]}, geometry=pts)
+
+        # associate observations with the network
+        args = self.network, obs.copy()
+        kwargs = {"df_name": "obs1", "df_key": "obs_id"}
+        self.net_obs = tigernet.Observations(*args, **kwargs)
+
+    def test_net_no_snap(self):
+        known_mtx = numpy.array(
+            [
+                [0.0, 0.0, 2.0, 2.0],
+                [0.0, 0.0, 2.0, 2.0],
+                [2.0, 2.0, 0.0, 0.0],
+                [2.0, 2.0, 0.0, 0.0],
+            ]
+        )
+        args = copy.deepcopy(self.net_obs), copy.deepcopy(self.network)
+        kwargs = {"dest_obs": None, "snap_dist": False, "distance_type": "network"}
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
+
+        known_mtx_sum = 16.0
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+    def test_net_snap(self):
+        known_mtx = numpy.array(
+            [
+                [0.0, 2.0, 4.0, 4.0],
+                [2.0, 0.0, 4.0, 4.0],
+                [4.0, 4.0, 0.0, 2.0],
+                [4.0, 4.0, 2.0, 0.0],
+            ]
+        )
+        args = copy.deepcopy(self.net_obs), copy.deepcopy(self.network)
+        kwargs = {"dest_obs": None, "snap_dist": True, "distance_type": "network"}
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
+
+        known_mtx_sum = 40.0
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+    def test_euc_no_snap(self):
+        known_mtx = numpy.array(
+            [
+                [0.0, 0.0, 2.0, 2.0],
+                [0.0, 0.0, 2.0, 2.0],
+                [2.0, 2.0, 0.0, 0.0],
+                [2.0, 2.0, 0.0, 0.0],
+            ]
+        )
+        args = copy.deepcopy(self.net_obs), copy.deepcopy(self.network)
+        kwargs = {"dest_obs": None, "snap_dist": False, "distance_type": "euclidean"}
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
+
+        known_mtx_sum = 16.0
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+    def test_euc_snap(self):
+        known_mtx = numpy.array(
+            [
+                [0.0, 0.0, 2.0, 2.0],
+                [0.0, 0.0, 2.0, 2.0],
+                [2.0, 2.0, 0.0, 0.0],
+                [2.0, 2.0, 0.0, 0.0],
+            ]
+        )
+        args = copy.deepcopy(self.net_obs), copy.deepcopy(self.network)
+        kwargs = {"dest_obs": None, "snap_dist": True, "distance_type": "euclidean"}
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
+
+        known_mtx_sum = 16.0
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+
+####################################################################################
+############################# ORIG-XXXX--Nodes #####################################
+####################################################################################
+
+
+class TestSyntheticObservationsOrigToXXXXNodes(unittest.TestCase):
+    def setUp(self):
+        self.network = copy.deepcopy(network_lattice_1x1_small)
+
+        # generate synthetic observations
+        pts = [Point(1, 1), Point(3, 1), Point(1, 3), Point(3, 3)]
+        obs = geopandas.GeoDataFrame({"obs_id": ["a", "b", "c", "d"]}, geometry=pts)
+
+        # associate observations with the network
+        args = self.network, obs.copy()
+        kwargs = {"df_name": "obs1", "df_key": "obs_id", "snap_to": "nodes"}
+        self.net_obs = tigernet.Observations(*args, **kwargs)
+
+    def test_net_no_snap(self):
+        known_mtx = numpy.array(
+            [
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+            ]
+        )
+        args = self.net_obs, self.network
+        kwargs = {"dest_obs": None, "snap_dist": False, "distance_type": "network"}
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
+
+        known_mtx_sum = 0.0
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+    def test_net_snap(self):
+        known_mtx = numpy.array(
+            [
+                [0.0, 2.82842712, 2.82842712, 2.82842712],
+                [2.82842712, 0.0, 2.82842712, 2.82842712],
+                [2.82842712, 2.82842712, 0.0, 2.82842712],
+                [2.82842712, 2.82842712, 2.82842712, 0.0],
+            ]
+        )
+        args = self.net_obs, self.network
+        kwargs = {"dest_obs": None, "snap_dist": True, "distance_type": "network"}
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
+
+        known_mtx_sum = 33.941125496954285
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+    def test_euc_no_snap(self):
+        known_mtx = numpy.array(
+            [
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+            ]
+        )
+        args = self.net_obs, self.network
+        kwargs = {"dest_obs": None, "snap_dist": False, "distance_type": "euclidean"}
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
+
+        known_mtx_sum = 0.0
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+    def test_euc_snap(self):
+        known_mtx = numpy.array(
+            [
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+            ]
+        )
+        args = self.net_obs, self.network
+        kwargs = {"dest_obs": None, "snap_dist": True, "distance_type": "euclidean"}
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
+
+        known_mtx_sum = 0.0
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+
+####################################################################################
+############################# ORIG-DEST--Segments ##################################
+####################################################################################
+
+
+class TestSyntheticObservationsOrigToDestSegments(unittest.TestCase):
+    def setUp(self):
+        self.network = copy.deepcopy(network_lattice_1x1_small)
+
+        # generate synthetic origins
+        obs1 = tigernet.generate_obs(5, self.network.s_data)
+        obs1["obs_id"] = ["a", "b", "c", "d", "e"]
+        # generate synthetic destinations
+        obs2 = tigernet.generate_obs(3, self.network.s_data, seed=1)
+        obs2["obs_id"] = ["z", "y", "x"]
+
+        # associate origins with the network
+        args = self.network, obs1.copy()
+        kwargs = {"df_name": "obs1", "df_key": "obs_id"}
+        self.net_obs1 = tigernet.Observations(*args, **kwargs)
+
+        # associate destinations with the network
+        args = self.network, obs2.copy()
+        kwargs = {"df_name": "obs2", "df_key": "obs_id"}
+        self.net_obs2 = tigernet.Observations(*args, **kwargs)
+
+    def test_net_no_snap(self):
+        known_mtx = numpy.array(
+            [
+                [0.02054051, 2.86029997, 2.49140309],
+                [1.29235148, 2.41059601, 2.04169913],
+                [0.29772152, 2.58311895, 2.21422207],
+                [0.68579403, 3.5666345, 3.19773762],
+                [2.73594902, 3.85419354, 3.48529666],
+            ]
+        )
+        args = copy.deepcopy(self.net_obs1), copy.deepcopy(self.network)
+        kwargs = {
+            "dest_obs": self.net_obs2,
+            "snap_dist": False,
+            "distance_type": "network",
+        }
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
+
+        known_mtx_sum = 33.737558095596384
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+    def test_net_snap(self):
+        known_mtx = numpy.array(
+            [
+                [0.54770651, 3.84622369, 4.09963354],
+                [1.80379619, 3.38079845, 3.63420829],
+                [0.93501431, 3.67916947, 3.93257931],
+                [1.26735717, 4.60695537, 4.86036522],
+                [3.53409492, 5.11109718, 5.36450702],
+            ]
+        )
+        args = copy.deepcopy(self.net_obs1), copy.deepcopy(self.network)
+        kwargs = {
+            "dest_obs": self.net_obs2,
+            "snap_dist": True,
+            "distance_type": "network",
+        }
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
+
+        known_mtx_sum = 50.60350662252801
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+    def test_euc_no_snap(self):
+        known_mtx = numpy.array(
+            [
+                [0.02054051, 2.17694135, 2.49140309],
+                [0.97244594, 2.41059601, 1.68165696],
+                [0.29772152, 2.08296224, 2.21422207],
+                [0.68579403, 2.54046208, 3.19773762],
+                [2.05339149, 3.85419354, 2.46956183],
+            ]
+        )
+        args = copy.deepcopy(self.net_obs1), copy.deepcopy(self.network)
+        kwargs = {
+            "dest_obs": self.net_obs2,
+            "snap_dist": False,
+            "distance_type": "euclidean",
+        }
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
+
+        known_mtx_sum = 29.14963026553491
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+    def test_euc_snap(self):
+        known_mtx = numpy.array(
+            [
+                [0.02054051, 2.17694135, 2.49140309],
+                [0.97244594, 2.41059601, 1.68165696],
+                [0.29772152, 2.08296224, 2.21422207],
+                [0.68579403, 2.54046208, 3.19773762],
+                [2.05339149, 3.85419354, 2.46956183],
+            ]
+        )
+        args = copy.deepcopy(self.net_obs1), copy.deepcopy(self.network)
+        kwargs = {
+            "dest_obs": self.net_obs2,
+            "snap_dist": True,
+            "distance_type": "euclidean",
+        }
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
+
+        known_mtx_sum = 29.14963026553491
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+
+####################################################################################
+############################# ORIG-DEST--Nodes #####################################
+####################################################################################
+
+
+class TestSyntheticObservationsOrigToDestNodes(unittest.TestCase):
+    def setUp(self):
+        self.network = copy.deepcopy(network_lattice_1x1_small)
+
+        # generate synthetic origins
+        obs1 = tigernet.generate_obs(5, self.network.s_data)
+        obs1["obs_id"] = ["a", "b", "c", "d", "e"]
+        # generate synthetic destinations
+        obs2 = tigernet.generate_obs(3, self.network.s_data, seed=1)
+        obs2["obs_id"] = ["z", "y", "x"]
+
+        # associate origins with the network
+        args = self.network, obs1.copy()
+        kwargs = {"df_name": "obs1", "df_key": "obs_id", "snap_to": "nodes"}
+        self.net_obs1 = tigernet.Observations(*args, **kwargs)
+
+        # associate destinations with the network
+        args = self.network, obs2.copy()
+        kwargs = {"df_name": "obs2", "df_key": "obs_id", "snap_to": "nodes"}
+        self.net_obs2 = tigernet.Observations(*args, **kwargs)
+
+    def test_net_no_snap(self):
+        known_mtx = numpy.array(
+            [
+                [0.0, 2.0, 2.0],
+                [0.0, 2.0, 2.0],
+                [0.0, 2.0, 2.0],
+                [2.0, 4.0, 4.0],
+                [2.0, 4.0, 4.0],
+            ]
+        )
+        args = self.net_obs1, self.network
+        kwargs = {
+            "dest_obs": self.net_obs2,
+            "snap_dist": False,
+            "distance_type": "network",
+        }
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
+
+        known_mtx_sum = 32.0
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+    def test_net_snap(self):
+        known_mtx = numpy.array(
+            [
+                [1.8243534, 3.67329521, 4.34307909],
+                [1.3902779, 3.23921971, 3.90900359],
+                [1.60037734, 3.44931915, 4.11910303],
+                [3.44146299, 5.2904048, 5.96018868],
+                [3.43009305, 5.27903486, 5.94881874],
+            ]
+        )
+        args = self.net_obs1, self.network
+        kwargs = {
+            "dest_obs": self.net_obs2,
+            "snap_dist": True,
+            "distance_type": "network",
+        }
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
+
+        known_mtx_sum = 56.89803154575887
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+    def test_euc_no_snap(self):
+        known_mtx = numpy.array(
+            [
+                [0.0, 2.0, 2.0],
+                [0.0, 2.0, 2.0],
+                [0.0, 2.0, 2.0],
+                [2.0, 2.82842712, 4.0],
+                [2.0, 4.0, 2.82842712],
+            ]
+        )
+        args = self.net_obs1, self.network
+        kwargs = {
+            "dest_obs": self.net_obs2,
+            "snap_dist": False,
+            "distance_type": "euclidean",
+        }
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
+
+        known_mtx_sum = 29.656854249492383
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+    def test_euc_snap(self):
+        known_mtx = numpy.array(
+            [
+                [0.0, 2.0, 2.0],
+                [0.0, 2.0, 2.0],
+                [0.0, 2.0, 2.0],
+                [2.0, 2.82842712, 4.0],
+                [2.0, 4.0, 2.82842712],
+            ]
+        )
+        args = self.net_obs1, self.network
+        kwargs = {
+            "dest_obs": self.net_obs2,
+            "snap_dist": True,
+            "distance_type": "euclidean",
+        }
+        observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
+        numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
+
+        known_mtx_sum = 29.656854249492383
+        observed_mtx_sum = observed_mtx.sum()
+        self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tigernet/tigernet.py
+++ b/tigernet/tigernet.py
@@ -873,13 +873,13 @@ def obs2obs_cost_matrix(
 
     Parameters
     ----------
-    orig : tigernet.Observations
-    net : tigernet.Network
-    dest : tigernet.Observations
+    origin_observations : tigernet.Observations
+    network : tigernet.Network
+    destination_observations : tigernet.Observations
         Destination observations. Default is ``None``.
     snap_dist : str
         Include the distance to observations from the network. Default is ``True``.
-    dist_type : str
+    distance_type : str
         Type of distance cost matrix. Default is ``'network'``.
         Option is ``'euclidean'``.
 
@@ -892,27 +892,27 @@ def obs2obs_cost_matrix(
 
     # ensure the network object has an associated cost matrix
     mtx_str = "n2n_matrix"
-    if not hasattr(net, mtx_str):
+    if not hasattr(network, mtx_str):
         msg = "The 'Network' has no '%s' attribute. " % mtx_str
         msg += "Run 'cost_matrix()' and try again."
         raise AttributeError(msg)
     else:
-        network_matrix = getattr(net, mtx_str)
+        network_matrix = getattr(network, mtx_str)
 
     # set the origin point dataframe
-    orig_obs = orig.snapped_points
+    orig_obs = origin_observations.snapped_points
 
     # set cost matrix as symmetric if no destination pattern is specified
-    if not dest:
-        orig_obs = orig_obs
+    if not destination_observations:
+        dest_obs = orig_obs
         symmetric = True
     else:
-        dest_obs = dest.snapped_points
+        dest_obs = destination_observations.snapped_points
         symmetric = False
 
     # determine whether calculating distance from
     # segments locations or from the nearest node
-    assoc = orig.snap_to
+    assoc = origin_observations.snap_to
     if assoc == "nodes":
         assoc_col = "assoc_node"
         from_nodes = True
@@ -935,7 +935,7 @@ def obs2obs_cost_matrix(
         numeric_cols += [snap_dist]
 
     # set the xy-id name from the ``Network``
-    xyid = net.xyid
+    xyid = network.xyid
 
     # generate the cost matrix
     n2m_matrix = utils.obs2obs_costs(
@@ -946,7 +946,7 @@ def obs2obs_cost_matrix(
         xyid=xyid,
         from_nodes=from_nodes,
         snap_dist=snap_dist,
-        dist_type=dist_type,
+        dist_type=distance_type,
         assoc_col=assoc_col,
         numeric_cols=numeric_cols,
     )

--- a/tigernet/utils.py
+++ b/tigernet/utils.py
@@ -2,17 +2,11 @@
 """
 
 from ast import literal_eval
-import copy
+import copy, re
 
 import geopandas
 import numpy
 import pandas
-from shapely.geometry import Point, MultiPoint
-from shapely.geometry import LineString, MultiLineString
-from shapely.geometry import GeometryCollection
-from shapely.ops import linemerge
-
-
 from shapely.geometry import Point, MultiPoint
 from shapely.geometry import LineString, MultiLineString
 from shapely.geometry import GeometryCollection
@@ -2530,3 +2524,302 @@ def snap_to_nearest(obs, net):
     snp_pts_df = fill_frame(snp_pts_df, idx="index", col=obs.xyid, data=node2xyid)
 
     return snp_pts_df
+
+
+def obs2obs_costs(
+    orig,
+    dest,
+    symmetric,
+    network_matrix,
+    from_nodes,
+    snap_dist,
+    assoc_col,
+    distance_type,
+    xyid,
+    numeric_cols,
+):
+    """Internal function to calculate a cost matrix
+    from (n) observations to (m) observations.
+
+    Parameters
+    ----------
+    orig : geopandas.GeoDataFrame
+        Origin observations.
+    dest : geopandas.GeoDataFrame
+        Destination observations.
+    symmetric : bool
+        Calculate an observation nXn cost matrix.
+    network_matrix : numpy.ndarray
+        'nXn' network nodes cost matrix.
+    from_nodes : bool
+        Calculate cost matrix from network nodes only.
+    snap_dist : str
+        Column name to use for distance to observation from the network.
+    assoc_col : str
+        Column name for network geometry snapping.
+    distance_type : str
+        Type of distance cost matrix.
+        Options are 'network_pp2n' and 'euclidean'. Default is None.
+    xyid : str
+        String xyID column name
+    numeric_cols : list
+        Columns to preprocess to ensure numeric values.
+
+    Returns
+    -------
+    n2m_matrix : numpy.ndarray
+        'nXm' cost matrix.
+
+    """
+
+    def _ensure_numeric(o, d, cols):
+        """Make sure dataframe columns are in proper numeric format.
+
+        Parameters
+        ----------
+        o : geopandas.GeoDataFrame
+            Origin observations.
+        d : geopandas.GeoDataFrame
+            Destination observations.
+        cols : list
+            Columns to preprocess to ensure numeric values.
+
+        Returns
+        -------
+        o : geopandas.GeoDataFrame
+            Origin observations.
+        d : geopandas.GeoDataFrame
+            Destination observations.
+
+        """
+
+        # having trouble keeping the integers and floats in numeric form
+        types = [int, float, numpy.int64, numpy.float64]
+
+        for col in cols:
+
+            if type(o[col][0]) not in types:
+                o[col] = o[col].apply(lambda x: literal_eval(x))
+
+            if type(d[col][0]) not in types:
+                d[col] = d[col].apply(lambda x: literal_eval(x))
+
+        return o, d
+
+    def _dist_calc(
+        o, i, isg, d, j, jsg, matrix, na="node_a", nb="node_b", da="dist_a", db="dist_b"
+    ):
+        """Get the cheapest cost route from snapped pt1 to snapped pt 2
+
+        Parameters
+        ----------
+        o : geopandas.GeoDataFrame
+            Origin observations.
+        i : int
+            Origin index.
+        isg : int
+            Segment associated with i.
+        d : geopandas.GeoDataFrame
+            Destination observations.
+        j : int
+            Destination index.
+        jsg : int
+            Segment associated with j.
+        matrix : numpy.ndarray
+            All node-to-all node network cost matrix.
+        na : str
+            Right node label (may actually be to the visual left).
+            Default is ``'R_node'``.
+        nb : str
+            left node label (may actually be to the visual right).
+            Default is ``'L_node'``.
+        da : str
+            Distance label to ``'rn'``. Default is ``'R_dist'``.
+        db : str
+            Distance label to ``'ln'``. Default is ``'L_dist'``.
+
+        Returns
+        -------
+        initial_dist : float or int
+            Distance from snapped point to snapped point.
+
+        """
+
+        # get node indices
+        ai, bi = o[na][i], o[nb][i]
+        aj, bj = d[na][j], d[nb][j]
+
+        # origin right and left distance
+        ai_dist, bi_dist = o[da][i], o[db][i]
+
+        # destination right and left distance
+        aj_dist, bj_dist = d[da][j], d[db][j]
+
+        # if observation nodes are snapped to the same segment
+        if (ai, bi) == (aj, bj) and isg == jsg:
+
+            # if the ORIGIN 'right' distance is greater than
+            # (or equal to) the DESTINATION 'right' distance then
+            # subtract the DESTINATION from the ORIGIN distance...
+            if ai_dist >= aj_dist:
+                initial_dist = ai_dist - aj_dist
+
+            # ... otherwise subtract the 'right' ORIGIN from
+            # the DESTINATION distance
+            else:
+                initial_dist = aj_dist - ai_dist
+
+        # observation nodes are snapped to different segments
+        else:
+            # get all combinations of potential distance
+            a2a = matrix[ai, aj]
+            a2b = matrix[ai, bj]
+            b2b = matrix[bi, bj]
+            b2a = matrix[bi, aj]
+
+            # create distance lookup dictionary
+            lookup = {
+                (ai, aj, "ai", "aj"): a2a,
+                (ai, bj, "ai", "bj"): a2b,
+                (bi, bj, "bi", "bj"): b2b,
+                (bi, aj, "bj", "aj"): b2a,
+            }
+
+            # get minimum distances and associated nodes ids
+            (n1, n2, pos_i, pos_j) = min(lookup, key=lookup.get)
+            initial_dist = min(lookup.values())
+
+            # evaulate the cheapest cost
+            # if the lookup decides the 'right' node for ORIGIN and the
+            # 'right' distance is lower than the 'left' distance add the
+            #'right' distance to the initial distance
+            if pos_i == "ai":
+                initial_dist += ai_dist
+
+            # otherwise add the 'left' distance to the initial distance
+            else:
+                initial_dist += bi_dist
+
+            # if the lookup decides the 'right' node for DESTINATION and
+            # the 'right' distance is lower than the 'left' distance
+            # add the 'right' distance to the initial distance
+            if pos_j == "aj":
+                initial_dist += aj_dist
+
+            # otherwise add the left distance to the initial distance
+            else:
+                initial_dist += bj_dist
+
+        return initial_dist
+
+    def _return_coords(xyid):
+        """Convert string (list) xyid into a tuple of (x,y) coordinates.
+
+        Parameters
+        ----------
+        xyid : str
+            String xy ID.
+
+        Returns
+        -------
+        coords : tuple
+            (x,y) coordinates.
+
+        """
+
+        # coerce the id into a plain string if in another text format
+        # and do literal evaluation to tease out ID from list (if list)
+        xyid = str(literal_eval(str(xyid))[0])
+
+        # characters to split by and ignore
+        chars = ["x", "y", ""]
+
+        # return numeric x and y coordinate split at 'x' and 'y'
+        coords = [float(c) for c in re.split("(x|y)", xyid) if c not in chars]
+        coords = tuple(coords)
+
+        return coords
+
+    # set matrix style
+    if symmetric:
+        dest = copy.deepcopy(orig)
+
+    # instantiate empty matrix
+    n2m_matrix = numpy.zeros((orig.shape[0], dest.shape[0]))
+
+    # Euclidean observation nodes distance matrix
+    if distance_type == "euclidean":
+        for ix in orig.index:
+            for jx in dest.index:
+                i, j = orig[xyid][ix], dest[xyid][jx]
+                p1, p2 = _return_coords(i), _return_coords(j)
+                n2m_matrix[ix, jx] = _euc_dist(p1, p2)
+
+    # network-style cost matrices
+    else:
+
+        # make sure node indices and distances are set to
+        # numeric values in dataframe columns
+        orig, dest = _ensure_numeric(orig, dest, numeric_cols)
+
+        # Network (from 'network nodes') distance matrix
+        if from_nodes:
+
+            for i in orig.index:
+
+                for j in dest.index:
+
+                    # if i and j are the same observation
+                    # there is no distance
+                    if i == j and symmetric:
+                        n2m_matrix[i, j] = 0.0
+
+                    else:
+                        I = orig.loc[i, assoc_col]  # i network node ID
+                        J = dest.loc[j, assoc_col]  # j network node ID
+                        # network i to j dist
+                        net_dist = network_matrix[I, J]
+
+                        # add in distance from observation to network
+                        if snap_dist:
+                            # snapped i dist
+                            from_i = orig[snap_dist][i]
+                            # snapped j dist
+                            from_j = dest[snap_dist][j]
+                            net_dist = from_i + from_j + net_dist
+
+                        n2m_matrix[i, j] = net_dist
+
+        # Network (from snapped point) distance matrix
+        else:
+
+            # complete distance
+            # start p1 --> snap point --> nearest node -->
+            # furtherst(closest) node --> snap point --> goal p2
+            for i in orig.index:
+
+                for j in dest.index:
+
+                    # if i and j are the same observation
+                    # there is no distance
+                    if i == j and symmetric:
+                        n2m_matrix[i, j] = 0.0
+
+                    else:
+                        # network segments associated with i and j
+                        isegm, jsegm = orig[assoc_col][i], dest[assoc_col][j]
+
+                        # calculate network distance from i to j
+                        network_dist = _dist_calc(
+                            orig, i, isegm, dest, j, jsegm, network_matrix
+                        )
+                        # add in distance from observation to network
+                        if snap_dist:
+                            orig_snap = orig[snap_dist][i]
+                            dest_snap = dest[snap_dist][j]
+                            dist_snap = orig_snap + dest_snap
+                            network_dist += dist_snap
+
+                        n2m_matrix[i, j] = network_dist
+
+    return n2m_matrix

--- a/tigernet/utils.py
+++ b/tigernet/utils.py
@@ -2534,7 +2534,7 @@ def obs2obs_costs(
     from_nodes,
     snap_dist,
     assoc_col,
-    distance_type,
+    dist_type,
     xyid,
     numeric_cols,
 ):
@@ -2557,7 +2557,7 @@ def obs2obs_costs(
         Column name to use for distance to observation from the network.
     assoc_col : str
         Column name for network geometry snapping.
-    distance_type : str
+    dist_type : str
         Type of distance cost matrix.
         Options are 'network_pp2n' and 'euclidean'. Default is None.
     xyid : str
@@ -2748,7 +2748,7 @@ def obs2obs_costs(
     n2m_matrix = numpy.zeros((orig.shape[0], dest.shape[0]))
 
     # Euclidean observation nodes distance matrix
-    if distance_type == "euclidean":
+    if dist_type == "euclidean":
         for ix in orig.index:
             for jx in dest.index:
                 i, j = orig[xyid][ix], dest[xyid][jx]


### PR DESCRIPTION
This PR adds cost matrix calculation for near-network observations.
* Type A to Type A
* Type A to Type B