### PR TITLE
fix sorting issue + temp fix for pyproj change

### DIFF
--- a/.ci/38.yaml
+++ b/.ci/38.yaml
@@ -6,8 +6,9 @@ dependencies:
   # required
   - geopandas>=0.8.0
   - libpysal>=4.3
-  - numpy>1.3
+  - numpy>=1.3
   - pandas>=1.0
+  - pyproj=2.6.1.post1
   - shapely>=1.7.1
   # testing
   - black

--- a/.ci/38.yaml
+++ b/.ci/38.yaml
@@ -6,7 +6,7 @@ dependencies:
   # required
   - geopandas>=0.8.0
   - libpysal>=4.3
-  - numpy<1.19.4
+  - numpy>1.3
   - pandas>=1.0
   - shapely>=1.7.1
   # testing

--- a/.ci/38.yaml
+++ b/.ci/38.yaml
@@ -6,7 +6,7 @@ dependencies:
   # required
   - geopandas>=0.8.0
   - libpysal>=4.3
-  - numpy>=1.3
+  - numpy<1.20.1
   - pandas>=1.0
   - shapely>=1.7.1
   # testing

--- a/.ci/38.yaml
+++ b/.ci/38.yaml
@@ -6,7 +6,7 @@ dependencies:
   # required
   - geopandas>=0.8.0
   - libpysal>=4.3
-  - numpy<1.20.1
+  - numpy<1.19.4
   - pandas>=1.0
   - shapely>=1.7.1
   # testing

--- a/.ci/39.yaml
+++ b/.ci/39.yaml
@@ -6,7 +6,7 @@ dependencies:
   # required
   - geopandas>=0.8.0
   - libpysal>=4.3
-  - numpy<1.19.4
+  - numpy>1.3
   - pandas>=1.0
   - shapely>=1.7.1
   # testing

--- a/.ci/39.yaml
+++ b/.ci/39.yaml
@@ -6,7 +6,7 @@ dependencies:
   # required
   - geopandas>=0.8.0
   - libpysal>=4.3
-  - numpy>=1.3
+  - numpy<1.20.1
   - pandas>=1.0
   - shapely>=1.7.1
   # testing

--- a/.ci/39.yaml
+++ b/.ci/39.yaml
@@ -8,6 +8,7 @@ dependencies:
   - libpysal>=4.3
   - numpy>1.3
   - pandas>=1.0
+  - pyproj=2.6.1.post1
   - shapely>=1.7.1
   # testing
   - black

--- a/.ci/39.yaml
+++ b/.ci/39.yaml
@@ -6,7 +6,7 @@ dependencies:
   # required
   - geopandas>=0.8.0
   - libpysal>=4.3
-  - numpy<1.20.1
+  - numpy<1.19.4
   - pandas>=1.0
   - shapely>=1.7.1
   # testing

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos: 
   - repo: https://github.com/ambv/black
-    rev: stable
+    rev: 20.8b1
     hooks: 
     - id: black
       language_version: python3.9

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@
    - pandas>=1.0
    - pip
    - pre-commit
+   - pyproj=2.6.1.post1
    - scipy
    - shapely>=1.7.1
    - watermark

--- a/requirements_conda.txt
+++ b/requirements_conda.txt
@@ -4,5 +4,6 @@ libpysal>=4.3
 numpy>=1.3
 pandas>=1.0
 pre-commit
+pyproj==2.6.1.post1
 shapely>=1.7.1
 spaghetti

--- a/tigernet/tests/test_obs2obs_synthetic.py
+++ b/tigernet/tests/test_obs2obs_synthetic.py
@@ -32,10 +32,10 @@ class TestSyntheticObservationsOrigToXXXXSegments(unittest.TestCase):
     def test_net_no_snap(self):
         known_mtx = numpy.array(
             [
-                [0.0, 0.0, 2.0, 2.0],
-                [0.0, 0.0, 2.0, 2.0],
-                [2.0, 2.0, 0.0, 0.0],
-                [2.0, 2.0, 0.0, 0.0],
+                [0.0, 2.0, 0.0, 2.0],
+                [2.0, 0.0, 2.0, 2.0],
+                [0.0, 2.0, 0.0, 2.0],
+                [2.0, 2.0, 2.0, 0.0],
             ]
         )
         args = copy.deepcopy(self.net_obs), copy.deepcopy(self.network)
@@ -47,17 +47,17 @@ class TestSyntheticObservationsOrigToXXXXSegments(unittest.TestCase):
         observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
         numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
 
-        known_mtx_sum = 16.0
+        known_mtx_sum = 20.0
         observed_mtx_sum = observed_mtx.sum()
         self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
 
     def test_net_snap(self):
         known_mtx = numpy.array(
             [
-                [0.0, 2.0, 4.0, 4.0],
-                [2.0, 0.0, 4.0, 4.0],
-                [4.0, 4.0, 0.0, 2.0],
-                [4.0, 4.0, 2.0, 0.0],
+                [0.0, 4.0, 2.0, 4.0],
+                [4.0, 0.0, 4.0, 4.0],
+                [2.0, 4.0, 0.0, 4.0],
+                [4.0, 4.0, 4.0, 0.0],
             ]
         )
         args = copy.deepcopy(self.net_obs), copy.deepcopy(self.network)
@@ -69,17 +69,17 @@ class TestSyntheticObservationsOrigToXXXXSegments(unittest.TestCase):
         observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
         numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
 
-        known_mtx_sum = 40.0
+        known_mtx_sum = 44.0
         observed_mtx_sum = observed_mtx.sum()
         self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
 
     def test_euc_no_snap(self):
         known_mtx = numpy.array(
             [
-                [0.0, 0.0, 2.0, 2.0],
-                [0.0, 0.0, 2.0, 2.0],
-                [2.0, 2.0, 0.0, 0.0],
-                [2.0, 2.0, 0.0, 0.0],
+                [0.0, 1.414214, 0.0, 1.414214],
+                [1.414214, 0.0, 1.414214, 2.0],
+                [0.0, 1.414214, 0.0, 1.414214],
+                [1.414214, 2.0, 1.414214, 0.0],
             ]
         )
         args = copy.deepcopy(self.net_obs), copy.deepcopy(self.network)
@@ -91,17 +91,17 @@ class TestSyntheticObservationsOrigToXXXXSegments(unittest.TestCase):
         observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
         numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
 
-        known_mtx_sum = 16.0
+        known_mtx_sum = 15.31370849898476
         observed_mtx_sum = observed_mtx.sum()
         self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
 
     def test_euc_snap(self):
         known_mtx = numpy.array(
             [
-                [0.0, 0.0, 2.0, 2.0],
-                [0.0, 0.0, 2.0, 2.0],
-                [2.0, 2.0, 0.0, 0.0],
-                [2.0, 2.0, 0.0, 0.0],
+                [0.0, 3.41421356, 2.0, 3.41421356],
+                [3.41421356, 0.0, 3.41421356, 4.0],
+                [2.0, 3.41421356, 0.0, 3.41421356],
+                [3.41421356, 4.0, 3.41421356, 0.0],
             ]
         )
         args = copy.deepcopy(self.net_obs), copy.deepcopy(self.network)
@@ -113,7 +113,7 @@ class TestSyntheticObservationsOrigToXXXXSegments(unittest.TestCase):
         observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
         numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
 
-        known_mtx_sum = 16.0
+        known_mtx_sum = 39.31370849898476
         observed_mtx_sum = observed_mtx.sum()
         self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
 
@@ -205,10 +205,10 @@ class TestSyntheticObservationsOrigToXXXXNodes(unittest.TestCase):
     def test_euc_snap(self):
         known_mtx = numpy.array(
             [
-                [0.0, 0.0, 0.0, 0.0],
-                [0.0, 0.0, 0.0, 0.0],
-                [0.0, 0.0, 0.0, 0.0],
-                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 2.82842712, 2.82842712, 2.82842712],
+                [2.82842712, 0.0, 2.82842712, 2.82842712],
+                [2.82842712, 2.82842712, 0.0, 2.82842712],
+                [2.82842712, 2.82842712, 2.82842712, 0.0],
             ]
         )
         args = self.net_obs, self.network
@@ -220,7 +220,7 @@ class TestSyntheticObservationsOrigToXXXXNodes(unittest.TestCase):
         observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
         numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
 
-        known_mtx_sum = 0.0
+        known_mtx_sum = 33.941125496954285
         observed_mtx_sum = observed_mtx.sum()
         self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
 
@@ -323,11 +323,11 @@ class TestSyntheticObservationsOrigToDestSegments(unittest.TestCase):
     def test_euc_snap(self):
         known_mtx = numpy.array(
             [
-                [0.02054051, 2.17694135, 2.49140309],
-                [0.97244594, 2.41059601, 1.68165696],
-                [0.29772152, 2.08296224, 2.21422207],
-                [0.68579403, 2.54046208, 3.19773762],
-                [2.05339149, 3.85419354, 2.46956183],
+                [0.54770651, 3.16286507, 4.09963354],
+                [1.48389065, 3.38079845, 3.27416613],
+                [0.93501431, 3.17901275, 3.93257931],
+                [1.26735717, 3.58078294, 4.86036522],
+                [2.85153739, 5.11109718, 4.34877219],
             ]
         )
         args = copy.deepcopy(self.net_obs1), copy.deepcopy(self.network)
@@ -339,7 +339,7 @@ class TestSyntheticObservationsOrigToDestSegments(unittest.TestCase):
         observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
         numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
 
-        known_mtx_sum = 29.14963026553491
+        known_mtx_sum = 46.015578792466535
         observed_mtx_sum = observed_mtx.sum()
         self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
 
@@ -442,11 +442,11 @@ class TestSyntheticObservationsOrigToDestNodes(unittest.TestCase):
     def test_euc_snap(self):
         known_mtx = numpy.array(
             [
-                [0.0, 2.0, 2.0],
-                [0.0, 2.0, 2.0],
-                [0.0, 2.0, 2.0],
-                [2.0, 2.82842712, 4.0],
-                [2.0, 4.0, 2.82842712],
+                [0.0, 3.67329521, 4.34307909],
+                [1.3902779, 3.23921971, 3.90900359],
+                [1.60037734, 3.44931915, 4.11910303],
+                [3.44146299, 4.11883193, 5.96018868],
+                [3.43009305, 5.27903486, 4.77724586],
             ]
         )
         args = self.net_obs1, self.network
@@ -458,7 +458,7 @@ class TestSyntheticObservationsOrigToDestNodes(unittest.TestCase):
         observed_mtx = tigernet.obs2obs_cost_matrix(*args, **kwargs)
         numpy.testing.assert_array_almost_equal(observed_mtx, known_mtx)
 
-        known_mtx_sum = 29.656854249492383
+        known_mtx_sum = 52.73053239487793
         observed_mtx_sum = observed_mtx.sum()
         self.assertAlmostEqual(observed_mtx_sum, known_mtx_sum)
 

--- a/tigernet/utils.py
+++ b/tigernet/utils.py
@@ -2184,6 +2184,8 @@ def snap_to_nearest(obs, net):
             segms_uu = segms_sub.unary_union
             near_points = []
 
+            segms_uu = sorted(segms_uu, key=lambda line: line.xy)
+
             for line in segms_uu:
                 near_pt = line.interpolate(line.project(opt))
                 near_points.append(near_pt)
@@ -2534,8 +2536,17 @@ def obs2obs_costs(
         for ix in orig.index:
             for jx in dest.index:
                 i, j = orig[xyid][ix], dest[xyid][jx]
-                p1, p2 = _return_coords(i), _return_coords(j)
-                n2m_matrix[ix, jx] = _euc_dist(p1, p2)
+                if i == j and ix == jx:
+                    euc_dist = 0.0
+                else:
+                    p1, p2 = _return_coords(i), _return_coords(j)
+                    euc_dist = _euc_dist(p1, p2)
+                    if snap_dist:
+                        orig_snap = orig[snap_dist][ix]
+                        dest_snap = dest[snap_dist][jx]
+                        dist_snap = orig_snap + dest_snap
+                        euc_dist += dist_snap
+                n2m_matrix[ix, jx] = euc_dist
 
     # network-style cost matrices
     else:


### PR DESCRIPTION
See #65 

try pinning `numpy`
* [x] `<1.20.1` — [failure](https://github.com/jGaboardi/tigernet/pull/66/checks?check_run_id=1887813684#step:6:118)
* [x] `<1.19.4{2}` — [failure](https://github.com/jGaboardi/tigernet/pull/66/checks?check_run_id=1887895003#step:6:118)
  * does not appear to be a `numpy` issue
  * dig into actual tests/failures for culprit
**not** a `numpy`... a `pyproj` change
* [x] see #67 