### PR TITLE
Use pytest-xdist

### DIFF
--- a/.ci/310.yaml
+++ b/.ci/310.yaml
@@ -18,3 +18,4 @@ dependencies:
   - codecov
   - pytest
   - pytest-cov
+  - pytest-xdist

--- a/.ci/38.yaml
+++ b/.ci/38.yaml
@@ -18,3 +18,4 @@ dependencies:
   - codecov
   - pytest
   - pytest-cov
+  - pytest-xdist

--- a/.ci/39.yaml
+++ b/.ci/39.yaml
@@ -18,3 +18,4 @@ dependencies:
   - codecov
   - pytest
   - pytest-cov
+  - pytest-xdist

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -37,12 +37,12 @@
        
        - name: run tests - bash
          shell: bash -l {0}
-         run: ${{ RUN_TEST }}
+         run: ${{ env.RUN_TEST }}
          if: matrix.os != 'windows-latest'
        
        - name: run tests - powershell
          shell: powershell
-         run: ${{ RUN_TEST }}
+         run: ${{ env.RUN_TEST }}
          if: matrix.os == 'windows-latest'
        
        - name: codecov

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -13,6 +13,8 @@
      name: conda (${{ matrix.os }}, ${{ matrix.environment-file }})
      runs-on: ${{ matrix.os }}
      timeout-minutes: 45
+     env:
+       RUN_TEST: pytest tigernet --cov tigernet -v -n auto --doctest-modules --cov-config .coveragerc --cov-report xml --color yes --cov-append --cov-report term-missing
      strategy:
        matrix:
          environment-file: [.ci/38.yaml, .ci/39.yaml, .ci/310.yaml]
@@ -35,12 +37,12 @@
        
        - name: run tests - bash
          shell: bash -l {0}
-         run: pytest -v tigernet --cov=tigernet --doctest-modules --cov-config=.coveragerc --cov-report=xml
+         run: ${{ RUN_TEST }}
          if: matrix.os != 'windows-latest'
        
        - name: run tests - powershell
          shell: powershell
-         run: pytest -v tigernet --cov=tigernet --doctest-modules --cov-config=.coveragerc --cov-report=xml
+         run: ${{ RUN_TEST }}
          if: matrix.os == 'windows-latest'
        
        - name: codecov

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -1,3 +1,4 @@
+codecov
 pytest
 pytest-cov
-codecov
+pytest-xdist

--- a/tigernet/tests/test_stats.py
+++ b/tigernet/tests/test_stats.py
@@ -154,12 +154,12 @@ class TestNetworkStatsSineLine(unittest.TestCase):
             1.1885699897294775,
         ]
         observed_sinuosity = list(self.network.s_data["sinuosity"])
-        self.assertEqual(observed_sinuosity, known_sinuosity)
+        self.assertAlmostEqual(observed_sinuosity, known_sinuosity)
 
     def test_sine_network_sinuosity_stats(self):
         known_max = 1.1913994275103448
         observed_max = self.network.max_sinuosity
-        self.assertEqual(observed_max, known_max)
+        self.assertAlmostEqual(observed_max, known_max)
 
         known_min = 1.0377484765201541
         observed_min = self.network.min_sinuosity
@@ -176,12 +176,12 @@ class TestNetworkStatsSineLine(unittest.TestCase):
     def test_sine_graph_sinuosity(self):
         known_sinuosity = [1.2105497715794307, 1.2105497715794304]
         observed_sinuosity = list(self.graph.s_data["sinuosity"])
-        self.assertEqual(observed_sinuosity, known_sinuosity)
+        self.assertAlmostEqual(observed_sinuosity, known_sinuosity)
 
     def test_sine_graph_sinuosity_stats(self):
         known_max = 1.2105497715794307
         observed_max = self.graph.max_sinuosity
-        self.assertEqual(observed_max, known_max)
+        self.assertAlmostEqual(observed_max, known_max)
 
         known_min = 1.2105497715794304
         observed_min = self.graph.min_sinuosity

--- a/tigernet/tests/test_stats.py
+++ b/tigernet/tests/test_stats.py
@@ -147,14 +147,16 @@ class TestNetworkStatsSineLine(unittest.TestCase):
             self.graph.calc_net_stats()
 
     def test_sine_network_sinuosity(self):
-        known_sinuosity = [
-            1.1913994275103448,
-            1.0377484765201541,
-            1.0714252226602858,
-            1.1885699897294775,
-        ]
-        observed_sinuosity = list(self.network.s_data["sinuosity"])
-        self.assertAlmostEqual(observed_sinuosity, known_sinuosity)
+        known_sinuosity = numpy.array(
+            [
+                1.1913994275103448,
+                1.0377484765201541,
+                1.0714252226602858,
+                1.1885699897294775,
+            ]
+        )
+        observed_sinuosity = self.network.s_data["sinuosity"]
+        numpy.testing.assert_array_almost_equal(observed_sinuosity, known_sinuosity)
 
     def test_sine_network_sinuosity_stats(self):
         known_max = 1.1913994275103448
@@ -163,20 +165,20 @@ class TestNetworkStatsSineLine(unittest.TestCase):
 
         known_min = 1.0377484765201541
         observed_min = self.network.min_sinuosity
-        self.assertEqual(observed_min, known_min)
+        self.assertAlmostEqual(observed_min, known_min)
 
         known_mean = 1.1222857791050656
         observed_mean = self.network.mean_sinuosity
-        self.assertEqual(observed_mean, known_mean)
+        self.assertAlmostEqual(observed_mean, known_mean)
 
         known_std = 0.07938019212245889
         observed_std = self.network.std_sinuosity
-        self.assertEqual(observed_std, known_std)
+        self.assertAlmostEqual(observed_std, known_std)
 
     def test_sine_graph_sinuosity(self):
-        known_sinuosity = [1.2105497715794307, 1.2105497715794304]
-        observed_sinuosity = list(self.graph.s_data["sinuosity"])
-        self.assertAlmostEqual(observed_sinuosity, known_sinuosity)
+        known_sinuosity = numpy.array([1.2105497715794307, 1.2105497715794304])
+        observed_sinuosity = self.graph.s_data["sinuosity"]
+        numpy.testing.assert_array_almost_equal(observed_sinuosity, known_sinuosity)
 
     def test_sine_graph_sinuosity_stats(self):
         known_max = 1.2105497715794307
@@ -185,15 +187,15 @@ class TestNetworkStatsSineLine(unittest.TestCase):
 
         known_min = 1.2105497715794304
         observed_min = self.graph.min_sinuosity
-        self.assertEqual(observed_min, known_min)
+        self.assertAlmostEqual(observed_min, known_min)
 
         known_mean = 1.2105497715794304
         observed_mean = self.graph.mean_sinuosity
-        self.assertEqual(observed_mean, known_mean)
+        self.assertAlmostEqual(observed_mean, known_mean)
 
         known_std = 2.220446049250313e-16
         observed_std = self.graph.std_sinuosity
-        self.assertEqual(observed_std, known_std)
+        self.assertAlmostEqual(observed_std, known_std)
 
     def test_sine_network_node_degree_stats(self):
         known_max = 2


### PR DESCRIPTION
Use `pytest-xdist` for multicore testing. Decreases runtime dramatically.